### PR TITLE
fix: rework pointers/references between Player and Level

### DIFF
--- a/src/gamelogic/Game.cpp
+++ b/src/gamelogic/Game.cpp
@@ -59,19 +59,19 @@ namespace GameLogic {
             }
         }
 
+        // Player start coords
+        CoordinateDouble coord = {10.5,1.5};
+        this->_player = std::make_shared<Player>(coord);
+
         // TODO: The AssetsManager should not be newed here
         this->_level = {
             std::make_shared<Level>(
-                Level(tiles, assets)
+                Level(*this->_player, tiles, assets)
             )
         };
+
         this->raycasting_engine.set_world(this->_level);
-
-        // Player start coords
-        CoordinateDouble coord = {10.5,1.5};
-        auto player = std::make_shared<Player>(coord, this->_level);
-
-        this->_level->set_player(player);
+        this->_player->set_level(this->_level);
     }
 
     /// \brief The main game loop

--- a/src/gamelogic/Game.hpp
+++ b/src/gamelogic/Game.hpp
@@ -15,6 +15,7 @@
 #include "Tile.hpp"
 #include "state/IGameState.hpp"
 #include "../engine/PathUtil.hpp"
+#include "Player.hpp"
 
 namespace GameLogic {
 
@@ -45,7 +46,7 @@ namespace GameLogic {
         SPTR_IGameState _new_state;
 
         SPTR_Level _level;
-        std::shared_ptr<Player> _player;
+        SPTR_Player _player;
     };
 }
 

--- a/src/gamelogic/Game.hpp
+++ b/src/gamelogic/Game.hpp
@@ -24,6 +24,8 @@ namespace GameLogic {
     using Engine::WorldPTR;
     using Engine::PathUtil;
 
+    class Player;
+
     class Game {
     public:
         Game();
@@ -43,7 +45,7 @@ namespace GameLogic {
         SPTR_IGameState _new_state;
 
         SPTR_Level _level;
-
+        std::shared_ptr<Player> _player;
     };
 }
 

--- a/src/gamelogic/Level.cpp
+++ b/src/gamelogic/Level.cpp
@@ -9,9 +9,10 @@ namespace GameLogic {
 
     using std::vector;
 
-    Level::Level(vector<vector<Tile*>> field, Engine::SPTR_AssetsManager assets)
+    Level::Level(Player& player, vector<vector<Tile*>> field, Engine::SPTR_AssetsManager assets)
     : World(assets)
     , _field(field)
+    , _player(player)
     {
     }
 
@@ -26,7 +27,7 @@ namespace GameLogic {
             }
         }
 
-        this->_player->update(delta_time);
+        this->_player.update(delta_time);
     }
 
     CoordinateDouble Level::get_spawnpoint()
@@ -41,17 +42,12 @@ namespace GameLogic {
 
     PointOfView& Level::get_pov()
     {
-        return *(this->_player);
-    }
-
-    void Level::set_player(shared_ptr<Player> player)
-    {
-        this->_player = player;
+        return this->_player;
     }
 
     void Level::handle_input(Engine::PressedKeys keys)
     {
-        this->_player->handleInput(keys);
+        this->_player.handleInput(keys);
     }
 
     Level::Level(const Level& obj)

--- a/src/gamelogic/Level.hpp
+++ b/src/gamelogic/Level.hpp
@@ -19,7 +19,6 @@ namespace GameLogic {
     using Engine::TileObject;
     using Engine::PointOfView;
     using Engine::AssetsManager;
-    using std::shared_ptr;
 
     class Player;
 
@@ -28,7 +27,7 @@ namespace GameLogic {
     private:
         vector<vector<Tile*>> _field; //TODO create a typedef for this
         CoordinateDouble _spawnpoint;
-        shared_ptr<Player> _player;
+        Player& _player;
 
         /*
          * WorldParser
@@ -38,12 +37,10 @@ namespace GameLogic {
          */
 
     public:
-        Level(vector<vector<Tile*>> field, Engine::SPTR_AssetsManager assets);
+        Level(Player& player, vector<vector<Tile*>> field, Engine::SPTR_AssetsManager assets);
         Level(const Level& obj);
 
         void update(int delta_time) override;
-
-        void set_player(shared_ptr<Player> player);
 
         TileObject* get_tile(int x, int y) override;
 

--- a/src/gamelogic/Player.cpp
+++ b/src/gamelogic/Player.cpp
@@ -6,9 +6,9 @@
 
 namespace GameLogic {
 
-    Player::Player(CoordinateDouble position, SPTR_Level world)
+    Player::Player(CoordinateDouble position)
     : PointOfView(position, Engine::RaycastingVector{-1, 0}, Engine::RaycastingVector{0, 0.66})
-    , _level(world)
+    , _level(nullptr)
     {
     }
 

--- a/src/gamelogic/Player.hpp
+++ b/src/gamelogic/Player.hpp
@@ -28,7 +28,7 @@ namespace GameLogic {
     class Player : public PointOfView {
 
     public:
-        Player(CoordinateDouble position, SPTR_Level level);
+        Player(CoordinateDouble position);
 
         bool is_at(int x, int y);
         void set_level(SPTR_Level level);

--- a/src/gamelogic/Player.hpp
+++ b/src/gamelogic/Player.hpp
@@ -63,6 +63,8 @@ namespace GameLogic {
          */
 
     };
+
+    typedef std::shared_ptr<Player> SPTR_Player;
 }
 
 #endif //MINOR_VIDYA_PLAYER_HPP


### PR DESCRIPTION
Before, there was a circular shared_ptr, causing a memory leak. Now,
Player is a reference of Level instead.

This commit closes #44