### PR TITLE
feat: make sure AssetsManager doesn't have tiles hardcoded

### DIFF
--- a/src/engine/AssetsManager.cpp
+++ b/src/engine/AssetsManager.cpp
@@ -32,8 +32,8 @@ namespace Engine {
             success = false;
         } else {
             this->_known_textures[0] = new ImageBuffer();
-            for (auto tile_pair : this->_tileset_map_to_id) {
-                this->_known_textures[tile_pair.first] = texture_map[tile_pair.second];
+            for (auto tile_pair : texture_map) {
+                this->_known_textures[tile_pair.first] = tile_pair.second;
             }
         }
 

--- a/src/engine/AssetsManager.hpp
+++ b/src/engine/AssetsManager.hpp
@@ -25,6 +25,8 @@ namespace Engine {
         bool _init_texture_map( string& texture_source, size_t tile_width, size_t tile_height, size_t tile_count );
         SDLFacade& _SDL_facade;
 
+        // TODO: This can be removed since it's unused.
+        // Although it might be good to set these on init so that they can be retrieved where needed (raycaster?)
         string _texture_source;
         size_t _tile_height;
         size_t _tile_width;

--- a/src/engine/AssetsManager.hpp
+++ b/src/engine/AssetsManager.hpp
@@ -29,13 +29,6 @@ namespace Engine {
         size_t _tile_height;
         size_t _tile_width;
         size_t _tile_count;
-
-        map<int, int> _tileset_map_to_id = {
-            { 1, 33 },    // Brick wall
-            { 2, 1 },     // Stone wall
-            { 3, 23 },    // Wood wall
-            { 4, 15}      // Blue wall
-        };
     };
 
     typedef std::shared_ptr<AssetsManager> SPTR_AssetsManager;


### PR DESCRIPTION
Now tiles painted in Tile2d actually are the tiles you will see in the
map ingame.